### PR TITLE
fix: pad collections with <4 items to avoid stretched images

### DIFF
--- a/Tasks/CollectionImageGeneratorTask.cs
+++ b/Tasks/CollectionImageGeneratorTask.cs
@@ -114,6 +114,12 @@ namespace Jellyfin.Plugin.CollectionImageGenerator.Tasks
                                 .Take(sampleSize)
                                 .ToList();
 
+                            // Pad to at least 4 items by duplicating posters to avoid stretched images
+                            while (sampleItems.Count < 4 && sampleItems.Count > 0)
+                            {
+                                sampleItems.Add(sampleItems[sampleItems.Count % itemsWithImages.Count]);
+                            }
+
                             _logger.LogInformation("Selected {Count} items for collage in collection {Name}",
                                 sampleItems.Count, boxSet.Name);
 


### PR DESCRIPTION
When a collection has fewer than 4 items, the collage generator would create a 1x1, 1x2, or 1x3 grid, stretching the poster images to fill the full canvas. This looked bad.

Fix: duplicate posters to always have at least 4 items, producing a clean 2x2 grid.

Closes #5