### PR TITLE
Fix plugin version showing as 0.0.0.0 in Jellyfin UI

### DIFF
--- a/Jellyfin.Plugin.CollectionImageGenerator.csproj
+++ b/Jellyfin.Plugin.CollectionImageGenerator.csproj
@@ -3,8 +3,9 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.CollectionImageGenerator</RootNamespace>
-    <AssemblyVersion>0.0.0.0</AssemblyVersion>
-    <FileVersion>0.0.0.0</FileVersion>
+    <Version>0.0.0.1</Version>
+    <AssemblyVersion>$(Version)</AssemblyVersion>
+    <FileVersion>$(Version)</FileVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
## Summary
- The csproj hardcoded `AssemblyVersion` and `FileVersion` to `0.0.0.0`
- CI passes `/p:Version=X` at build time, but `AssemblyVersion`/`FileVersion` weren't derived from `$(Version)` — so they stayed `0.0.0.0` in the compiled DLL
- This caused the Jellyfin web UI to display version `0.0.0.0` and broke plugin management (uninstall button failed due to version mismatch between folder name, meta.json, and assembly)

## Fix
`AssemblyVersion` and `FileVersion` now derive from `$(Version)`, so the CI override propagates correctly. Local builds default to `0.0.0.1` instead of `0.0.0.0`.

## Test plan
- [ ] Merge to main, let CI release a new version
- [ ] Install the new version on Jellyfin via the plugin repo
- [ ] Confirm the Plugins page shows the correct version (e.g. `0.0.0.25`)
- [ ] Confirm the uninstall button works from the web UI